### PR TITLE
Fix for logout(): Call completion handler with empty response instead of not calling it at all.

### DIFF
--- a/Source/SynologyClient.swift
+++ b/Source/SynologyClient.swift
@@ -124,6 +124,12 @@ public class SynologyClient {
             completion(.failure(.invalidResponse(response)))
             return
         }
+        
+        if T.self == EmptyResponse.self {
+            completion(.success(EmptyResponse() as! T))
+            return
+        }
+
         do {
             let decodedRes = try JSONDecoder().decode(SynologyResponse<T>.self, from: data)
             if let data = decodedRes.data {


### PR DESCRIPTION
`handleDataResponse<T>()` did not call the completion handler when it is used with` T.self == EmptyResponse.self`. This happens when it is called in response to `logout()`. There is no data to decode in this case, therefore `decodedRes.data` would be nil, although there is no error either, and the callback would be skipped.